### PR TITLE
Enable Docker container to start successfully in AWS

### DIFF
--- a/bin/get-ssm-parameters.sh
+++ b/bin/get-ssm-parameters.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+
+# Pulls in HackO API env var values as parameters from AWS Parameter Store
+# Depends on pre-installed awscli
+
+# Modelled on https://aws.amazon.com/blogs/compute/managing-secrets-for-amazon-ecs-applications-using-parameter-store-and-iam-roles-for-tasks/
+
+EC2_REGION="us-west-2" # unfortunately cannot rely on dynamic env var values that this script is meant to pull in
+NAMESPACE="/production/2018/API" # future-proofing this script for subsequent or past containers
+PROJECT_CANONICAL_NAME="neighborhood-development" # must be set to each project's "Final naming convention" from here https://github.com/hackoregon/civic-devops/issues/1
+
+# Get unencrypted values
+POSTGRES_HOST=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_HOST --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+POSTGRES_NAME=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_NAME --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+POSTGRES_PORT=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_PORT --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+POSTGRES_USER=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_USER --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+
+# Note: this env var value is for the WSGI startup - corresponds to the folder name where the base Django project is stored in the repo
+PROJECT_NAME=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/PROJECT_NAME --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+
+# Get encrypted values
+DJANGO_SECRET_KEY=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/DJANGO_SECRET_KEY --with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+POSTGRES_PASSWORD=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_PASSWORD --with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+
+# Set environment variables in the container
+export DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY
+export POSTGRES_HOST=$POSTGRES_HOST
+export POSTGRES_NAME=$POSTGRES_NAME
+export POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+export POSTGRES_PORT=$POSTGRES_PORT
+export POSTGRES_USER=$POSTGRES_USER
+export PROJECT_NAME=$PROJECT_NAME

--- a/bin/production-docker-entrypoint.sh
+++ b/bin/production-docker-entrypoint.sh
@@ -6,6 +6,10 @@ set -e
 
 echo Debug: $DEBUG
 
+# Pull in environment variables values from AWS Parameter Store, and preserve the exports
+# source usage per https://stackoverflow.com/q/14742358/452120
+source /code/bin/get-ssm-parameters.sh
+
 python -Wall manage.py collectstatic --noinput
 
 gunicorn $PROJECT_NAME.wsgi -c gunicorn_config.py

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,3 +8,6 @@ gevent==1.3a1
  # DB connector for Green Connections
 psycogreen==1.0
 django-db-geventpool
+
+# install for use by get-ssm-parameters.sh script
+awscli


### PR DESCRIPTION
Acquire runtime env vars from AWS Parameter Store to enable containerized Django app to start successfully in production.

This relies on a working Travis build, test and upload to ECR.  Once the `ecs-deploy.sh` script has a working Docker image in ECR, this PR will ensure that deployed image in ECS will be able to connect to its database.