### PR TITLE
Change production build pipeline and routes for ECS deployment

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -4,7 +4,7 @@ from rest_framework_swagger.views import get_swagger_view
 
 from . import views
 
-schema_view = get_swagger_view(title='Hack Oregon 2018 Transportation Systems APIs')
+schema_view = get_swagger_view(title='Hack Oregon 2018 Neighborhood Development APIs')
 
 urlpatterns = [
     path('', schema_view),

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,10 +1,13 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
+from rest_framework_swagger.views import get_swagger_view
 
 from . import views
 
+schema_view = get_swagger_view(title='Hack Oregon 2018 Transportation Systems APIs')
 
 urlpatterns = [
+    path('', schema_view),
     path('crimes', views.CrimesList.as_view()),
     path('affordable_housing', views.AffordableHousingList.as_view()),
     path('camp_sweeps', views.CampSweepsList.as_view()),

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,7 +4,7 @@
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 
     # Push only if we're testing the master branch
-    #if [ "$TRAVIS_BRANCH" == "master" ]; then
+    if [ "$TRAVIS_BRANCH" == "master" ]; then
 
         # remove until such time as anybody can remember why it is here
         # export PATH=$PATH:$HOME/.local/bin
@@ -13,11 +13,11 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         eval $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
 
         REMOTE_DOCKER_PATH="$DOCKER_REPO"/"$DOCKER_REPO_NAMESPACE"/"$DOCKER_IMAGE"
-        
+
         # tag with branch and travis build number then push
         TAG=travis-buildnum-"$TRAVIS_BUILD_NUMBER"
         echo Tagging with "$TAG"
-        docker tag "$DOCKER_IMAGE":latest "$REMOTE_DOCKER_PATH":"$TAG"    
+        docker tag "$DOCKER_IMAGE":latest "$REMOTE_DOCKER_PATH":"$TAG"
         docker push "$REMOTE_DOCKER_PATH":"$TAG"
 
         # tag with "latest" then push
@@ -25,16 +25,16 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         echo Tagging with "$TAG"
         docker tag "$DOCKER_IMAGE":latest "$REMOTE_DOCKER_PATH":"$TAG"
         docker push "$REMOTE_DOCKER_PATH":"$TAG"
-        
+
         #echo Running ecs-deploy.sh script...
         bin/ecs-deploy.sh  \
            --service-name "$ECS_SERVICE_NAME" \
            --cluster "$ECS_CLUSTER"   \
            --image "$REMOTE_DOCKER_PATH":latest \
            --timeout 300
-    #else
-    #    echo "Skipping deploy because branch is not master"
-    #fi
+    else
+       echo "Skipping deploy because branch is not master"
+    fi
 else
     echo "Skipping deploy because it's a pull request"
 fi

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -9,7 +9,7 @@ while getopts ":dp" opt; do
           docker-compose -f development-docker-compose.yml run --entrypoint /code/bin/test-entrypoint.sh api_development -p 8000
           ;;
         p)
-          docker-compose -f production-docker-compose.yml run --entrypoint /code/bin/test-entrypoint.sh $DOCKER_SERVICE -p 8000
+          docker-compose -f production-docker-compose.yml run --entrypoint /code/bin/test-entrypoint.sh $DOCKER_IMAGE -p 8000
           ;;
         *)
           usage

--- a/neighborhoods_backend/settings.py
+++ b/neighborhoods_backend/settings.py
@@ -169,7 +169,7 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
-STATIC_URL = '/static/'
+STATIC_URL = '/neighborhood-development/static/'
 
 #custom test runner to toggle between Managed=True and Managed=False for models handling test db
 #TEST_RUNNER = 'api.utils.UnManagedModelTestRunner'

--- a/production-docker-compose.yml
+++ b/production-docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3.4'
 services:
-  api_production:
+  neighborhood-development:
     build:
       context: .
       dockerfile: DOCKERFILE.api.production
-    image: api_production
+    image: $DOCKER_IMAGE
     command: ./bin/production-docker-entrypoint.sh
     volumes:
       - .:/code


### PR DESCRIPTION
✨ so shiny ✨ 

![image](https://user-images.githubusercontent.com/174740/40890433-cae28ede-672a-11e8-9aff-c77ad6ffa0c0.png)

**This boiled down to a few things.**

1. Make sure that there is route for `/neighborhood-development/`. Without this index route being handled, django responds with a 404 and the load balancer health check in AWS fails, causes the deploy to rollback.
2. Changing the container name to `neighborhood-development`. The exemplar uses `api_production` by default, but it needed to be changed to the final name.
3. Configuring static files to be found at `/neighborhood-development/static/`. The entirety of this API container is routed at `/neighborhood-development/`, static files included.