### PR TITLE
livingalone view was using incorrect meta object

### DIFF
--- a/civic_sandbox/meta.py
+++ b/civic_sandbox/meta.py
@@ -397,7 +397,7 @@ living_alone_meta = {
 'attributes': {
   'primary': {
     'field': 'pc_householders_living_alone',
-    'name': 'Householders Living Alone',
+    'name': 'Percent of Householders Living Alone',
     'visualization': {
       'type': 'PercentDonut',
       'comparison_value': None,

--- a/civic_sandbox/views.py
+++ b/civic_sandbox/views.py
@@ -181,8 +181,8 @@ livingalone = sandbox_view_factory(
   serializer_class=LivingAloneSerializer,
   multi_geom_class=MultiPolygon,
   geom_field='geom',
-  attributes =population_meta['attributes'],
-  dates=population_meta['dates'], 
+  attributes =living_alone_meta['attributes'],
+  dates=living_alone_meta['dates'], 
   )
 
 income = sandbox_view_factory(


### PR DESCRIPTION
livingalone view was being created by calling sandbox_view_factory() with total_poplation meta object's attributes. Use correct meta object livingalone_meta.